### PR TITLE
C20 16 news crear api endpoint para guardar una entrada de novedades

### DIFF
--- a/app/api/auth/[...nextauth]/route.js
+++ b/app/api/auth/[...nextauth]/route.js
@@ -34,8 +34,11 @@ const handler = NextAuth({
 	],
 
 	callbacks: {
-		async jwt({ token, user }) {
-			token.role = user?.role
+		async jwt({ token, user, trigger }) {
+			if (trigger === 'signIn') {
+				token.role = user?.role
+				token.userId = user?.id
+			}
 			return token
 		},
 	},

--- a/app/api/news/route.js
+++ b/app/api/news/route.js
@@ -1,0 +1,74 @@
+// eslint-disable-next-line no-unused-vars
+import { NextRequest, NextResponse } from 'next/server'
+// eslint-disable-next-line no-unused-vars
+import { Schema, ValidationError } from 'yup'
+import { getToken } from 'next-auth/jwt'
+import prisma from '../../../lib/prisma'
+import { ErrorObject } from '../../../lib/error'
+import { newsSchema } from './schema'
+import { addNews } from '../../../services/news'
+
+/**
+ * Handles the GET request for retrieving news data.
+ * @returns {NextResponse} The response object containing the news data.
+ */
+export async function GET() {
+	const data = await prisma.news.findMany()
+	return NextResponse.json({ data })
+}
+
+/**
+ * Handles the POST request for adding news.
+ * @param {NextRequest} req - The request object.
+ * @returns {NextResponse} The response object.
+ */
+export async function POST(req) {
+	try {
+		const { userId } = await validateUser(req)
+		const validatedNews = await validateRequest(req, newsSchema)
+		validatedNews.authorId = userId
+		const news = await addNews(validatedNews)
+		return NextResponse.json({ data: news }, { status: 201 })
+	} catch (ex) {
+		return NextResponse.json(
+			{ message: ex.message, errors: ex.errors },
+			{ status: ex.statusCode ?? 500 }
+		)
+	}
+}
+
+/**
+ * Validates the request body against a schema.
+ * @param {NextRequest} req req - The request object.
+ * @param {Schema} schema - The validation schema.
+ * @returns {Promise<object>} The validated data.
+ * @throws {ErrorObject} If the validation fails.
+ */
+async function validateRequest(req, schema) {
+	try {
+		const body = await req.json()
+		return await schema.validate(body, {
+			stripUnknown: true,
+			abortEarly: false,
+		})
+	} catch (ex) {
+		const error = new ErrorObject({ message: ex.message })
+		if (ex instanceof ValidationError || ex instanceof SyntaxError) {
+			error.statusCode = 400
+		}
+		throw error
+	}
+}
+
+/**
+ * Validates the user and retrieves the user data from the request.
+ * @param {NextRequest} req - The request object.
+ * @returns {Promise<Object>} The user data.
+ * @throws {ErrorObject} If the user validation fails or the user is unauthorized.
+ */
+async function validateUser(req) {
+	const token = await getToken({ req })
+	if (!token)
+		throw new ErrorObject({ message: 'Unauthorized', statusCode: 401 })
+	return token
+}

--- a/app/api/news/schema.js
+++ b/app/api/news/schema.js
@@ -1,0 +1,14 @@
+import * as Yup from 'yup'
+
+export const newsSchema = Yup.object().shape({
+	title: Yup.string()
+		.required()
+		.min(4, 'must be at least 4 characters long')
+		.max(32, 'must be less than 32 characters long'),
+	imageUrl: Yup.string().url().required(),
+	description: Yup.string()
+		.required()
+		.min(12, 'must be at least 12 characters long')
+		.max(2048, 'must be less than 2048 characters long'),
+	published: Yup.boolean().notRequired().default(false),
+})

--- a/lib/prisma.js
+++ b/lib/prisma.js
@@ -1,16 +1,17 @@
 import { PrismaClient } from '@prisma/client'
 
-/* declare global {
-  var prisma: PrismaClient | undefined
+// Docs about instantiating `PrismaClient` with Next.js:
+// https://pris.ly/d/help/next-js-best-practices
+
+let prisma
+
+if (process.env.NODE_ENV === 'production') {
+	prisma = new PrismaClient()
+} else {
+	if (!global.prisma) {
+		global.prisma = new PrismaClient()
+	}
+	prisma = global.prisma
 }
-
-const prisma = global.prisma || new PrismaClient()
-
-if (process.env.NODE_ENV === 'development') global.prisma = prisma
-*/
-
-const prisma = new PrismaClient({
-	log: ['info'],
-})
 
 export default prisma


### PR DESCRIPTION
COMO: usuario
QUIERO: agregar una novedad
PARA: almacenar las actividades de la asociación.

Criterios de aceptación:
API Endpoint para la creación de una novedad.
URL: /api/news
Método POST
Validar usuario
Validar request
Devuelve el objeto creado o error
Nombre de tabla a usar:   News
Campos:  title, imageUrl, description, published (bool)